### PR TITLE
feat: support esm&cjs dual module systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,32 @@
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",
+  "exports": {
+    ".": {
+      "browser": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "node": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      },
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "browser": {
+        "types": "./dist/*.d.ts",
+        "default": "./dist/*.js"
+      },
+      "node": {
+        "types": "./dist/*.d.cts",
+        "default": "./dist/*.cjs"
+      },
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    }
+  },
   "types": "dist/index.d.ts",
   "directories": {
     "dist": "dist"
@@ -55,9 +81,6 @@
     "*.{js,jsx,json,yml,yaml,html,md,ts,tsx}": [
       "biome format --no-errors-on-unmatched --write"
     ]
-  },
-  "dependencies": {
-    "flat": "6.0.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  flat:
-    specifier: 6.0.1
-    version: 6.0.1
-
 devDependencies:
   '@biomejs/biome':
     specifier: ^1.5.3
@@ -2456,12 +2451,6 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
     dev: true
-
-  /flat@6.0.1:
-    resolution: {integrity: sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw==}
-    engines: {node: '>=18'}
-    hasBin: true
-    dev: false
 
   /follow-redirects@1.15.5:
     resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -10,7 +10,6 @@ import {
   ObjectType,
 } from "./Types";
 import * as Guard from "./Guard";
-import { flatten } from "flat";
 
 /**
  * @see https://tools.ietf.org/html/rfc6570#section-3.2.2
@@ -243,3 +242,19 @@ export const generateFromLabel = (key: string | number, params: ParameterOfLabel
   }
   return ".";
 };
+
+function flatten<T extends object, R extends Record<string, unknown>>(obj: T): R {
+  function recursive(path: string[], data: object, flatted: Record<string, unknown>) {
+    for (const [key, value] of Object.entries(data)) {
+      const currentPath = [...path, key];
+      if (Guard.isObject(value)) {
+        recursive(currentPath, value, flatted);
+      } else {
+        flatted[currentPath.join(".")] = value;
+      }
+    }
+  }
+  const flatted = {} as R;
+  recursive([], obj, flatted);
+  return flatted;
+}


### PR DESCRIPTION
### Problem
The `@himenon/openapi-parameter-formatter` uses `tsup` since version 2.0.0.
It's great choice to support esm&cjs dual packages.

but I found the package.json mistake and `esm only` dependencies.

This PR aims to solve those problems.

### Solution

- Add `package.json#exports` field
- Remove `flat` package that only supports `esm` environment